### PR TITLE
text overflow sidebar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,95 +1,95 @@
 html,
 body {
-    height: 100%;
-    margin: 0;
+  height: 100%;
+  margin: 0;
 }
 
 .notes {
-    display: flex;
-    height: 100%;
+  display: flex;
+  height: 100%;
 }
 
 .notes * {
-    font-family: sans-serif;
+  font-family: sans-serif;
 }
 
 .notes__sidebar {
-    border-right: 2px solid #dddddd;
-    flex-shrink: 0;
-    overflow-y: auto;
-    padding: 1em;
-    width: 300px;
+  border-right: 2px solid #dddddd;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 1em;
+  width: 300px;
 }
 
 .notes__add {
-    background: #009578;
-    border: none;
-    border-radius: 7px;
-    color: #ffffff;
-    cursor: pointer;
-    font-size: 1.25em;
-    font-weight: bold;
-    margin-bottom: 1em;
-    padding: 0.75em 0;
-    width: 100%;
+  background: #009578;
+  border: none;
+  border-radius: 7px;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 1.25em;
+  font-weight: bold;
+  margin-bottom: 1em;
+  padding: 0.75em 0;
+  width: 100%;
 }
 
 .notes__add:hover {
-    background: #00af8c;
+  background: #00af8c;
 }
 
 .notes__list-item {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .notes__list-item--selected {
-    background: #eeeeee;
-    border-radius: 7px;
-    font-weight: bold;
+  background: #eeeeee;
+  border-radius: 7px;
+  font-weight: bold;
 }
 
 .notes__small-title,
 .notes__small-updated {
-    padding: 10px;
+  padding: 10px;
 }
 
-.notes__small-title {
-    font-size: 1.2em;
-}
-
+.notes__small-title,
 .notes__small-body {
-    padding: 0 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 10px;
 }
 
 .notes__small-updated {
-    color: #aaaaaa;
-    font-style: italic;
-    text-align: right;
+  color: #aaaaaa;
+  font-style: italic;
+  text-align: right;
 }
 
 .notes__preview {
-    display: flex;
-    flex-direction: column;
-    padding: 2em 3em;
-    flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2em 3em;
+  flex-grow: 1;
 }
 
 .notes__title,
 .notes__body {
-    border: none;
-    outline: none;
-    width: 100%;
+  border: none;
+  outline: none;
+  width: 100%;
 }
 
 .notes__title {
-    font-size: 3em;
-    font-weight: bold;
+  font-size: 3em;
+  font-weight: bold;
 }
 
 .notes__body {
-    flex-grow: 1;
-    font-size: 1.2em;
-    line-height: 1.5;
-    margin-top: 2em;
-    resize: none;
+  flex-grow: 1;
+  font-size: 1.2em;
+  line-height: 1.5;
+  margin-top: 2em;
+  resize: none;
 }


### PR DESCRIPTION
FIXES #4

the sidebar text overflow happened because the length of the text content(title/body) was larger than the width of the sidebar container. it didnt have enough space to display the full text, so that's why it overflowed.

Earlier
![Screenshot 2024-03-15 102443](https://github.com/iiitl/Note_Generator/assets/143445493/89098c54-5fd7-4cb0-9f45-d1696da1afd3)


in the pull request, i have made some changes to the main.css file only. specifically made changes to the properties .notes__small-title and .notes__small-body classes. after these changes, if the text length is more than the width of the sidebar container, it will be truncated and '...' will be shown at the end which indicates that the text has been cut off.

After changes
![image](https://github.com/iiitl/Note_Generator/assets/143445493/b871f9c1-dc33-4dc8-a28c-e2fb65960c3e)

